### PR TITLE
Fix parsear en watts el maxímetro de los cierres mensuales

### DIFF
--- a/plc800stg/billings.py
+++ b/plc800stg/billings.py
@@ -38,7 +38,7 @@ class PlcMonthlyBillingsParser(object):
                 index_capacitativa = index_inductiva + num_periods
                 capacitativa = int(row[index_capacitativa])
                 index_maxim = index_capacitativa + num_periods
-                maxim = float(row[index_maxim])
+                maxim = int(float(row[index_maxim])*1000)
                 billing = {
                     'name': meter_name,
                     'contract': contract,


### PR DESCRIPTION
Transformar el maxímetro de los cierres mensuales a watts, dado que el valor que se expresa en los ficheros de lecturas de los plc800 viene en kilowatts.